### PR TITLE
feat: add column mapping write support for new tables

### DIFF
--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -583,6 +583,15 @@ impl ProtocolInner {
         }
         self
     }
+
+    /// Enable column mapping feature in the protocol
+    pub fn enable_column_mapping(mut self) -> Self {
+        // Column mapping requires reader features (min_reader_version=3)
+        // and writer features (min_writer_version=7)
+        self = self.append_reader_features([TableFeature::ColumnMapping]);
+        self = self.append_writer_features([TableFeature::ColumnMapping]);
+        self
+    }
 }
 
 /// High level table features

--- a/crates/core/src/kernel/schema/schema.rs
+++ b/crates/core/src/kernel/schema/schema.rs
@@ -1,6 +1,7 @@
 //! Delta table schema
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub use delta_kernel::schema::{
@@ -8,6 +9,7 @@ pub use delta_kernel::schema::{
     StructField, StructType,
 };
 use serde_json::Value;
+use uuid::Uuid;
 
 use crate::kernel::error::Error;
 use crate::schema::DataCheck;
@@ -58,6 +60,15 @@ pub trait StructTypeExt {
 
     /// Get all generated column expressions
     fn get_generated_columns(&self) -> Result<Vec<GeneratedColumn>, Error>;
+
+    /// Add column mapping metadata to all fields in the schema.
+    /// This generates unique physical names (UUIDs) and assigns sequential column IDs.
+    /// Returns a new schema with column mapping metadata added to all fields.
+    fn with_column_mapping_metadata(&self) -> Result<StructType, Error>;
+
+    /// Build a mapping from logical column names to physical column names
+    /// based on the column mapping metadata in this schema.
+    fn get_logical_to_physical_mapping(&self) -> HashMap<String, String>;
 }
 
 impl StructTypeExt for StructType {
@@ -153,6 +164,134 @@ impl StructTypeExt for StructType {
             }
         }
         Ok(invariants)
+    }
+
+    /// Add column mapping metadata to all fields in the schema.
+    /// This generates unique physical names (UUIDs) and assigns sequential column IDs.
+    fn with_column_mapping_metadata(&self) -> Result<StructType, Error> {
+        let mut column_id_counter = 1i64;
+
+        fn add_metadata_to_field(
+            field: &StructField,
+            counter: &mut i64,
+        ) -> Result<StructField, Error> {
+            // Generate physical name and column ID
+            let physical_name = format!("col-{}", Uuid::new_v4());
+            let column_id = *counter;
+            *counter += 1;
+
+            // Build new metadata with column mapping info
+            let mut metadata: Vec<(String, MetadataValue)> = field
+                .metadata()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+
+            metadata.push((
+                "delta.columnMapping.id".to_string(),
+                MetadataValue::Number(column_id),
+            ));
+            metadata.push((
+                "delta.columnMapping.physicalName".to_string(),
+                MetadataValue::String(physical_name),
+            ));
+
+            // Handle nested types recursively
+            let new_data_type = match field.data_type() {
+                DataType::Struct(inner) => {
+                    let new_fields: Result<Vec<StructField>, Error> = inner
+                        .fields()
+                        .map(|f| add_metadata_to_field(f, counter))
+                        .collect();
+                    DataType::Struct(Box::new(
+                        StructType::try_new(new_fields?).map_err(|e| Error::Generic(e.to_string()))?,
+                    ))
+                }
+                DataType::Array(inner) => {
+                    // For arrays, the element type might need metadata if it's a struct
+                    if let DataType::Struct(elem_struct) = inner.element_type() {
+                        let new_fields: Result<Vec<StructField>, Error> = elem_struct
+                            .fields()
+                            .map(|f| add_metadata_to_field(f, counter))
+                            .collect();
+                        DataType::Array(Box::new(ArrayType::new(
+                            DataType::Struct(Box::new(
+                                StructType::try_new(new_fields?)
+                                    .map_err(|e| Error::Generic(e.to_string()))?,
+                            )),
+                            inner.contains_null(),
+                        )))
+                    } else {
+                        field.data_type().clone()
+                    }
+                }
+                DataType::Map(inner) => {
+                    // For maps, value type might need metadata if it's a struct
+                    let new_key_type = inner.key_type().clone();
+                    let new_value_type = if let DataType::Struct(val_struct) = inner.value_type() {
+                        let new_fields: Result<Vec<StructField>, Error> = val_struct
+                            .fields()
+                            .map(|f| add_metadata_to_field(f, counter))
+                            .collect();
+                        DataType::Struct(Box::new(
+                            StructType::try_new(new_fields?)
+                                .map_err(|e| Error::Generic(e.to_string()))?,
+                        ))
+                    } else {
+                        inner.value_type().clone()
+                    };
+                    DataType::Map(Box::new(MapType::new(
+                        new_key_type,
+                        new_value_type,
+                        inner.value_contains_null(),
+                    )))
+                }
+                _ => field.data_type().clone(),
+            };
+
+            // Create new field with updated data type and metadata
+            let new_field = if field.is_nullable() {
+                StructField::nullable(field.name(), new_data_type)
+            } else {
+                StructField::not_null(field.name(), new_data_type)
+            };
+
+            Ok(new_field.with_metadata(metadata))
+        }
+
+        let new_fields: Result<Vec<StructField>, Error> = self
+            .fields()
+            .map(|f| add_metadata_to_field(f, &mut column_id_counter))
+            .collect();
+
+        StructType::try_new(new_fields?).map_err(|e| Error::Generic(e.to_string()))
+    }
+
+    /// Build a mapping from logical column names to physical column names
+    fn get_logical_to_physical_mapping(&self) -> HashMap<String, String> {
+        fn collect_mappings(schema: &StructType, result: &mut HashMap<String, String>) {
+            for field in schema.fields() {
+                let logical_name = field.name().to_string();
+
+                // Get physical name from metadata if present
+                if let Some(MetadataValue::String(physical_name)) =
+                    field.metadata().get("delta.columnMapping.physicalName")
+                {
+                    if &logical_name != physical_name {
+                        result.insert(logical_name.clone(), physical_name.clone());
+                    }
+                }
+
+                // Recursively handle nested structs
+                if let DataType::Struct(nested) = field.data_type() {
+                    collect_mappings(nested.as_ref(), result);
+                }
+            }
+        }
+
+        let mut mappings = HashMap::new();
+        collect_mappings(self, &mut mappings);
+        mappings
     }
 }
 

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -15,7 +15,7 @@ use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL, TableReference};
 use crate::kernel::{
     Action, DataType, MetadataExt, ProtocolExt as _, ProtocolInner, StructField, StructType,
-    new_metadata,
+    StructTypeExt, new_metadata,
 };
 use crate::logstore::LogStoreRef;
 use crate::protocol::{DeltaOperation, SaveMode};
@@ -280,11 +280,17 @@ impl CreateBuilder {
         let operation_id = self.get_operation_id();
         self.pre_execute(operation_id).await?;
 
-        let configuration = self
+        let configuration: HashMap<String, String> = self
             .configuration
             .iter()
             .filter_map(|(k, v)| Some((k.to_string(), v.as_ref()?.to_string())))
             .collect();
+
+        // Check if column mapping is enabled in configuration
+        let column_mapping_enabled = configuration
+            .get("delta.columnMapping.mode")
+            .map(|mode| mode == "name" || mode == "id")
+            .unwrap_or(false);
 
         let current_protocol = ProtocolInner {
             min_reader_version: PROTOCOL.default_reader_version(),
@@ -304,12 +310,25 @@ impl CreateBuilder {
             })
             .unwrap_or_else(|| current_protocol);
 
+        // Create schema, adding column mapping metadata if enabled
         let schema = StructType::try_new(self.columns)?;
+        let schema = if column_mapping_enabled {
+            schema.with_column_mapping_metadata()?
+        } else {
+            schema
+        };
 
-        let protocol = protocol
+        // Apply protocol settings, enabling column mapping feature if needed
+        let mut protocol = protocol
             .apply_properties_to_protocol(&configuration, self.raise_if_key_not_exists)?
             .apply_column_metadata_to_protocol(&schema)?
             .move_table_properties_into_features(&configuration);
+
+        // Enable column mapping feature in protocol if needed
+        if column_mapping_enabled {
+            let inner = ProtocolInner::from_kernel(&protocol);
+            protocol = inner.enable_column_mapping().as_kernel();
+        }
 
         let mut metadata = new_metadata(
             &schema,

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -314,6 +314,40 @@ pub(crate) async fn write_execution_plan_v2(
     predicate: Option<Expr>,
     contains_cdc: bool,
 ) -> DeltaResult<(Vec<Action>, WriteExecutionPlanMetrics)> {
+    write_execution_plan_v3(
+        snapshot,
+        session,
+        plan,
+        partition_columns,
+        object_store,
+        target_file_size,
+        write_batch_size,
+        writer_properties,
+        writer_stats_config,
+        predicate,
+        contains_cdc,
+        None, // No target schema for column mapping - use snapshot or default
+    )
+    .await
+}
+
+/// Version 3 of write_execution_plan that supports column mapping for new tables
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn write_execution_plan_v3(
+    snapshot: Option<&EagerSnapshot>,
+    session: &dyn Session,
+    plan: Arc<dyn ExecutionPlan>,
+    partition_columns: Vec<String>,
+    object_store: ObjectStoreRef,
+    target_file_size: Option<usize>,
+    write_batch_size: Option<usize>,
+    writer_properties: Option<WriterProperties>,
+    writer_stats_config: WriterStatsConfig,
+    predicate: Option<Expr>,
+    contains_cdc: bool,
+    // Optional target schema with column mapping metadata for new tables
+    target_schema_with_column_mapping: Option<&StructType>,
+) -> DeltaResult<(Vec<Action>, WriteExecutionPlanMetrics)> {
     // We always take the plan Schema since the data may contain Large/View arrow types,
     // the schema and batches were prior constructed with this in mind.
     let schema = plan.schema();
@@ -342,6 +376,14 @@ pub(crate) async fn write_execution_plan_v2(
         let mode = snapshot.table_configuration().column_mapping_mode();
         let mapping = build_logical_to_physical_mapping(&snapshot.schema(), mode);
         (mode, mapping)
+    } else if let Some(target_schema) = target_schema_with_column_mapping {
+        // For new tables with column mapping, extract mapping from target schema metadata
+        let mapping = target_schema.get_logical_to_physical_mapping();
+        if mapping.is_empty() {
+            (ColumnMappingMode::None, HashMap::new())
+        } else {
+            (ColumnMappingMode::Name, mapping)
+        }
     } else {
         (ColumnMappingMode::None, HashMap::new())
     };

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -47,7 +47,7 @@ use tracing::Instrument;
 use url::Url;
 
 pub use self::configs::WriterStatsConfig;
-use self::execution::{prepare_predicate_actions, write_execution_plan_v2};
+use self::execution::{prepare_predicate_actions, write_execution_plan_v2, write_execution_plan_v3};
 use self::generated_columns::{gc_is_enabled, with_generated_columns};
 use self::metrics::{SOURCE_COUNT_ID, SOURCE_COUNT_METRIC};
 use self::schema_evolution::try_cast_schema;
@@ -686,8 +686,31 @@ impl std::future::IntoFuture for WriteBuilder {
 
                 let source_plan = session.create_physical_plan(&source).await?;
 
+                // Extract schema with column mapping metadata if creating a new table
+                // with column mapping enabled
+                let target_schema_with_column_mapping: Option<StructType> =
+                    if this.snapshot.is_none() {
+                        // For new tables, check if there's a Metadata action with schema
+                        actions
+                            .iter()
+                            .find_map(|a| {
+                                if let Action::Metadata(m) = a {
+                                    // Parse the schema and check if it has column mapping metadata
+                                    m.parse_schema().ok()
+                                } else {
+                                    None
+                                }
+                            })
+                            .filter(|schema| {
+                                // Only use if schema has column mapping metadata
+                                !schema.get_logical_to_physical_mapping().is_empty()
+                            })
+                    } else {
+                        None
+                    };
+
                 // Here we need to validate if the new data conforms to a predicate if one is provided
-                let (add_actions, _) = write_execution_plan_v2(
+                let (add_actions, _) = write_execution_plan_v3(
                     this.snapshot.as_ref(),
                     session.as_ref(),
                     source_plan.clone(),
@@ -699,6 +722,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     writer_stats_config.clone(),
                     predicate.clone(),
                     contains_cdc,
+                    target_schema_with_column_mapping.as_ref(),
                 )
                 .await?;
 

--- a/python/test_deltalake_write_pyspark_read.py
+++ b/python/test_deltalake_write_pyspark_read.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Test 2: delta-rs writes a Delta table with column mapping enabled, PySpark reads it.
+"""
+
+import os
+import sys
+import tempfile
+import shutil
+import uuid
+
+# ============================================================
+# Part 1: Create Delta table with delta-rs (column mapping mode)
+# ============================================================
+print("="*60)
+print("Creating Delta table with delta-rs (column mapping mode)")
+print("="*60)
+
+test_dir = "/tmp/delta_column_mapping_test_deltalake"
+table_path = os.path.join(test_dir, "deltalake_table")
+
+# Clean up any previous test
+if os.path.exists(test_dir):
+    shutil.rmtree(test_dir)
+os.makedirs(test_dir)
+
+print(f"\nTable path: {table_path}")
+
+import pyarrow as pa
+import deltalake
+from deltalake import DeltaTable, write_deltalake
+
+print(f"deltalake version: {deltalake.__version__}")
+
+
+def generate_physical_name():
+    """Generate a UUID-based physical column name like PySpark does."""
+    return f"col-{uuid.uuid4()}"
+
+
+def add_column_mapping_metadata(schema: pa.Schema) -> pa.Schema:
+    """Add column mapping metadata to a PyArrow schema."""
+    new_fields = []
+    for idx, field in enumerate(schema):
+        # Generate physical name and column ID
+        physical_name = generate_physical_name()
+        column_id = str(idx + 1)
+
+        # Add metadata
+        metadata = dict(field.metadata) if field.metadata else {}
+        metadata[b"delta.columnMapping.id"] = column_id.encode()
+        metadata[b"delta.columnMapping.physicalName"] = physical_name.encode()
+
+        new_field = pa.field(field.name, field.type, field.nullable, metadata)
+        new_fields.append(new_field)
+
+    return pa.schema(new_fields)
+
+
+# Create sample data with PyArrow
+original_schema = pa.schema([
+    ("id", pa.int64()),
+    ("user name", pa.string()),
+    ("age", pa.int64()),
+    ("salary amount", pa.float64()),
+])
+
+# NOTE: Do NOT add column mapping metadata manually!
+# When creating a new table with column mapping, delta-rs should handle this automatically.
+# Adding metadata manually causes validation errors because the kernel checks schema
+# metadata against the column mapping mode BEFORE the configuration is applied.
+
+print("\nUsing schema WITHOUT column mapping metadata:")
+for field in original_schema:
+    print(f"  {field.name}: {field.type}")
+
+data = pa.table({
+    "id": [1, 2, 3, 4, 5],
+    "user name": ["Alice", "Bob", "Charlie", "Diana", "Eve"],
+    "age": [30, 25, 35, 28, 32],
+    "salary amount": [50000.0, 60000.0, 70000.0, 55000.0, 65000.0],
+}, schema=original_schema)
+
+print("\nOriginal data:")
+print(data.to_pandas())
+
+# Write to Delta with column mapping mode enabled
+print(f"\nWriting to Delta table with column mapping mode = 'name'...")
+write_deltalake(
+    table_path,
+    data,
+    mode="overwrite",
+    configuration={
+        "delta.columnMapping.mode": "name",
+    },
+)
+
+print("Delta table created successfully!")
+
+# Read back with delta-rs to verify
+print("\n" + "-"*60)
+print("Reading back with delta-rs:")
+print("-"*60)
+dt = DeltaTable(table_path)
+print(f"Table version: {dt.version()}")
+print(f"Column mapping mode: {dt._table.get_column_mapping_mode()}")
+print("\nSchema:")
+for field in dt.schema().fields:
+    print(f"  - {field.name}: {field.type}")
+    if field.metadata:
+        for key, value in field.metadata.items():
+            print(f"      {key}: {value}")
+
+table_read = dt.to_pyarrow_table()
+print(f"\nData read by delta-rs:")
+print(table_read.to_pandas())
+
+# Show what's in the delta log
+print("\n" + "-"*60)
+print("Delta log contents:")
+print("-"*60)
+delta_log_path = os.path.join(table_path, "_delta_log")
+for f in sorted(os.listdir(delta_log_path)):
+    if f.endswith('.json'):
+        print(f"\n  {f}:")
+        with open(os.path.join(delta_log_path, f)) as fp:
+            for line in fp:
+                print(f"    {line.strip()[:200]}...")
+
+# ============================================================
+# Part 2: Read Delta table with PySpark
+# ============================================================
+print("\n\n" + "="*60)
+print("Reading Delta table with PySpark")
+print("="*60)
+
+# Local jars path
+jars_dir = "/home/user/delta-rs/python/jars"
+jar_files = [
+    os.path.join(jars_dir, "delta-spark_2.13-4.0.1.jar"),
+    os.path.join(jars_dir, "delta-storage-4.0.1.jar"),
+    os.path.join(jars_dir, "antlr4-runtime-4.13.1.jar"),
+]
+jars_string = ",".join(jar_files)
+
+from pyspark.sql import SparkSession
+
+# Configure Spark with local jars (no Maven resolution)
+spark = SparkSession.builder \
+    .appName("DeltaColumnMappingReadTest") \
+    .config("spark.jars", jars_string) \
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
+    .config("spark.driver.memory", "2g") \
+    .config("spark.sql.warehouse.dir", test_dir) \
+    .master("local[*]") \
+    .getOrCreate()
+
+spark.sparkContext.setLogLevel("ERROR")
+print("Spark session created successfully!")
+
+try:
+    print(f"\nReading Delta table from: {table_path}")
+    spark_df = spark.read.format("delta").load(table_path)
+
+    print("\nPySpark schema:")
+    spark_df.printSchema()
+
+    print("\nData read by PySpark:")
+    spark_df.show()
+
+    # Convert to pandas for comparison
+    pandas_df = spark_df.toPandas()
+    print("\nPySpark data as pandas DataFrame:")
+    print(pandas_df)
+
+    # Verify data matches
+    original_df = data.to_pandas()
+
+    # Sort both dataframes by 'id' for comparison
+    original_sorted = original_df.sort_values('id').reset_index(drop=True)
+    spark_sorted = pandas_df.sort_values('id').reset_index(drop=True)
+
+    # Compare
+    if original_sorted.equals(spark_sorted):
+        print("\n" + "="*60)
+        print("SUCCESS: PySpark correctly read delta-rs column mapping table!")
+        print("Data matches perfectly!")
+        print("="*60)
+    else:
+        print("\n" + "!"*60)
+        print("WARNING: Data mismatch!")
+        print("Original:")
+        print(original_sorted)
+        print("\nPySpark read:")
+        print(spark_sorted)
+        print("!"*60)
+
+except Exception as e:
+    print(f"\nERROR reading with PySpark: {type(e).__name__}: {e}")
+    import traceback
+    traceback.print_exc()
+    print("\n" + "="*60)
+    print("FAILED: PySpark could not read the delta-rs column mapping table")
+    print("="*60)
+
+finally:
+    spark.stop()
+    print("\nPySpark session stopped.")
+
+# ============================================================
+# Part 3: Direct parquet inspection
+# ============================================================
+print("\n\n" + "="*60)
+print("Part 3: Direct parquet inspection")
+print("="*60)
+
+import pyarrow.parquet as pq
+
+parquet_files = [f for f in os.listdir(table_path) if f.endswith('.parquet')]
+if parquet_files:
+    parquet_path = os.path.join(table_path, parquet_files[0])
+    print(f"\nReading parquet file directly: {parquet_files[0]}")
+    pq_table = pq.read_table(parquet_path)
+    print(f"\nParquet schema:")
+    print(pq_table.schema)
+    print(f"\nParquet column names: {pq_table.column_names}")
+    print(f"\nParquet data:")
+    print(pq_table.to_pandas())
+
+print(f"\n\nTest table preserved at: {table_path}")
+print("Done!")


### PR DESCRIPTION
This commit adds support for creating new Delta tables with column mapping mode enabled (delta.columnMapping.mode = "name" or "id").

Changes:
- Add with_column_mapping_metadata() to StructTypeExt to generate column mapping metadata (id, physicalName) for schema fields
- Add get_logical_to_physical_mapping() to extract mappings from schema
- Add enable_column_mapping() to ProtocolInner to set reader/writer features
- Update CreateBuilder to detect column mapping in configuration and:
  - Add column mapping metadata to schema fields
  - Enable column mapping protocol features
- Add write_execution_plan_v3() that accepts target schema for new tables
- Update WriteBuilder to pass target schema with column mapping for new tables
- Add test for delta-rs writes column mapping table that PySpark can read

Both directions now work:
- PySpark writes column mapping table -> delta-rs reads it ✓
- delta-rs writes column mapping table -> PySpark reads it ✓

# Description
The description of the main changes of your pull request

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
