### PR TITLE
fix: collapse nested if statement to fix clippy warning

### DIFF
--- a/crates/core/src/kernel/schema/schema.rs
+++ b/crates/core/src/kernel/schema/schema.rs
@@ -280,10 +280,9 @@ impl StructTypeExt for StructType {
                 // Get physical name from metadata if present
                 if let Some(MetadataValue::String(physical_name)) =
                     field.metadata().get("delta.columnMapping.physicalName")
+                    && &logical_name != physical_name
                 {
-                    if &logical_name != physical_name {
-                        result.insert(logical_name.clone(), physical_name.clone());
-                    }
+                    result.insert(logical_name.clone(), physical_name.clone());
                 }
 
                 // Recursively handle nested structs


### PR DESCRIPTION
Use if-let chains instead of nested if statements in get_logical_to_physical_mapping() to satisfy clippy::collapsible_if lint.

# Description
The description of the main changes of your pull request

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
